### PR TITLE
Add a (hopefully) simpler interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,18 @@ jobs:
       - run:
           name: Publish to NPM
           command: npx published
+  glossary:
+    <<: *defaults
+    machine: true
+    steps:
+      - run:
+          name: Add to Glossary
+          command: |
+            curl --user ${CIRCLECI_API_TOKEN}: \
+              --header "Content-Type: application/json" \
+              --data "{\"build_parameters\":{\"TRIGGERING_REPOSITORY\":\"${CIRCLE_REPOSITORY_URL}\"}}" \
+              --request POST \
+              https://circleci.com/api/v1.1/project/github/fiverr/glossary/tree/master
 
 workflows:
   version: 2
@@ -61,6 +73,14 @@ workflows:
           context: org-global
           requires:
             - test
+          filters:
+            branches:
+              only:
+                - master
+      - glossary:
+          context: org-global
+          requires:
+            - publish
           filters:
             branches:
               only:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,1 @@
-test.js
-**/test.js
-test-helpers.js
+node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,5 +18,18 @@
   "plugins": [],
   "rules": {
     "no-console": 0
-  }
+  },
+  "overrides": [
+    {
+      "files": [ "test.js", "**/test.js", "test-helpers.js" ],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "global": true,
+        "expect": true,
+        "assert": true
+      }
+    }
+  ]
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/gofor/index.js
+++ b/gofor/index.js
@@ -41,6 +41,20 @@ module.exports = class Gofor {
                 throw new TypeError('Gofor Error: Defaults have already been defined');
             };
         }
+
+        /**
+         * fetch wrapper
+         * @param  {String} url       Implied by fetch API
+         * @param  {Object} options[] Implied by fetch API
+         * @return {Promise}          A fetch promise
+         */
+        this.fetch = (...args) => {
+            args[1] = this.setOptions(args[1]);
+
+            return fetch(...args);
+        };
+
+        this.fetch.config = this.config.bind(this);
     }
 
     /**
@@ -89,15 +103,9 @@ module.exports = class Gofor {
         return options;
     }
 
-    /**
-     * [fetch description]
-     * @param  {String} url       Implied by fetch API
-     * @param  {Object} options[] Implied by fetch API
-     * @return {Promise}          A fetch promise
-     */
-    fetch(...args) {
-        args[1] = this.setOptions(args[1]);
+    config(opts = null) {
+        this[defaults] = this.setOptions(opts);
 
-        return fetch(...args);
+        return this[defaults];
     }
 };

--- a/gofor/test.js
+++ b/gofor/test.js
@@ -33,7 +33,7 @@ describe('Gofor/defaults', () => {
     });
     it('defaults getter methods must return objects', () => {
         assert.throws(() => (new Gofor(() => null)).fetch('https://www.website.com'), TypeError);
-        assert.throws(() => (new Gofor(() => ''  )).fetch('https://www.website.com'), TypeError);
+        assert.throws(() => (new Gofor(() => '')).fetch('https://www.website.com'), TypeError);
     });
 });
 
@@ -59,7 +59,7 @@ describe('Gofor/headers', () => {
         global.fetch = (url, {headers}) => {
             expect(headers['X-Requested-With']).to.equal('fetch');
             called = true;
-        }
+        };
 
         const gofor = new Gofor(defaults());
         gofor.fetch('/', {headers: {

--- a/gofor/test.js
+++ b/gofor/test.js
@@ -88,3 +88,20 @@ describe('Gofor/setOptions', () => {
         assert.equal(options.headers.get('X-Requested-With'), 'XMLHttpRequest');
     });
 });
+
+describe('gofor.config', () => {
+    const gofor = new Gofor(() => defaults());
+    const {fetch} = gofor;
+
+    it('Should modify the defaults', () => {
+        const headers = new Headers();
+        headers.append('Content-Type', 'text-plain');
+
+        fetch.config({headers});
+
+        const options = gofor.defaults;
+        assert.equal(options.headers.get('Content-Type'), 'text-plain');
+        assert.equal(options.headers.get('X-Custom-Authentication'), defaults().headers['X-Custom-Authentication']);
+        assert.equal(options.headers.get('X-Requested-With'), 'XMLHttpRequest');
+    });
+});

--- a/index.js
+++ b/index.js
@@ -11,8 +11,11 @@ const Gofor = require('./gofor');
  * @param  {Object|Function} def[] See Gofor constructor interface
  * @return {fetch} A wrapper Gofor fetch
  */
-module.exports = (...args) => {
-    const instance = new Gofor(...args);
-
-    return instance.fetch.bind(instance);
-};
+module.exports = (...args) => new Gofor(...args).fetch;
+Object.defineProperties(
+    module.exports,
+    {
+        fetch: { get: () => new Gofor().fetch },
+        gofor: { get: () => new Gofor().fetch }
+    }
+);

--- a/merge-headers/test.js
+++ b/merge-headers/test.js
@@ -19,9 +19,9 @@ describe('mergeHeaders', () => {
         defaults.append('key4', '4');
 
         const keys = parseHeaders(mergeHeaders(submitted, defaults))
-            .map(item => Object.keys(item)[0]);
+            .map((item) => Object.keys(item)[0]);
 
-        expect(keys).to.deep.equal(['key1','key2','key3','key4']);
+        expect(keys).to.deep.equal(['key1', 'key2', 'key3', 'key4']);
     });
 
     it('merges identical keys from both headers', () => {
@@ -34,9 +34,9 @@ describe('mergeHeaders', () => {
         defaults.append('key2', '4');
 
         const keys = parseHeaders(mergeHeaders(submitted, defaults))
-            .map(item => Object.keys(item)[0])
+            .map((item) => Object.keys(item)[0]);
 
-        expect(keys).to.deep.equal(['key1','key2']);
+        expect(keys).to.deep.equal(['key1', 'key2']);
     });
 
     it('Does not merge keys\' values. Submitted run over defaults', () => {
@@ -49,7 +49,7 @@ describe('mergeHeaders', () => {
         defaults.append('key2', '4');
 
         const values = parseHeaders(mergeHeaders(submitted, defaults))
-            .map(item => Object.values(item)[0]);
+            .map((item) => Object.values(item)[0]);
 
         expect(values).to.deep.equal(['1', '2']);
     });
@@ -62,7 +62,7 @@ describe('mergeHeaders', () => {
         defaults.append('keY1', '3');
 
         const values = parseHeaders(mergeHeaders(submitted, defaults))
-            .map(item => Object.values(item)[0]);
+            .map((item) => Object.values(item)[0]);
 
         expect(values).to.deep.equal(['1']);
     });

--- a/package.json
+++ b/package.json
@@ -4,18 +4,19 @@
   "description": "lean fetch decorator that reverse merges default options",
   "author": "Fiverr",
   "license": "MIT",
-  "main": "index.js",
+  "homepage": "https://github.com/fiverr/gofor#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fiverr/gofor.git"
+  },
   "engines": {
     "node": ">=6.9.4"
   },
+  "main": "index.js",
   "scripts": {
     "test": "mocha test.js **/test.js --inspect --require test-helpers.js",
     "lint": "eslint -c .eslintrc '*.js' '**/*.js'",
     "prepublishOnly": "npm t && npm run lint"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/fiverr/gofor.git"
   },
   "devDependencies": {
     "@fiverr/eslint-config-fiverr": "^1.0.0",
@@ -24,6 +25,5 @@
     "eslint-plugin-react": "^7.10.0",
     "mocha": "^5.2.0",
     "node-fetch": "^2.2.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/gofor",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "lean fetch decorator that reverse merges default options",
   "author": "Fiverr",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "mocha test.js **/test.js --inspect --require test-helpers.js",
-    "lint": "eslint -c .eslintrc *.js **/*.js --quiet",
+    "lint": "eslint -c .eslintrc '*.js' '**/*.js'",
     "prepublishOnly": "npm t && npm run lint"
   },
   "repository": {
@@ -20,10 +20,10 @@
   "devDependencies": {
     "@fiverr/eslint-config-fiverr": "^1.0.0",
     "chai": "^4.1.2",
-    "eslint": "^4.19.1",
-    "eslint-plugin-react": "^7.7.0",
-    "mocha": "^5.0.5",
-    "node-fetch": "^2.1.2"
+    "eslint": "^5.2.0",
+    "eslint-plugin-react": "^7.10.0",
+    "mocha": "^5.2.0",
+    "node-fetch": "^2.2.0"
   },
   "dependencies": {}
 }

--- a/parse-headers/test.js
+++ b/parse-headers/test.js
@@ -19,7 +19,7 @@ describe('parseHeaders', () => {
     it('converts Headers to literal object', () => {
         const list = [
             {a: '1'},
-            {b: '2'},
+            {b: '2'}
         ];
 
         const headers = new Headers();
@@ -35,9 +35,9 @@ describe('parseHeaders', () => {
         headers.append('a', '2');
 
         expect(parseHeaders(headers)).to.satisfy(
-            (res) => res[0]['a']
+            (res) => res[0].a
                 .split(',')
-                .map(i => i.trim())
+                .map((i) => i.trim())
                 .join(',') === '1,2'
         );
     });

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # gofor
 
-[![npm](https://img.shields.io/npm/v/@fiverr/gofor.svg)](https://www.npmjs.com/package/@fiverr/gofor)
-[![CircleCI](https://img.shields.io/circleci/project/github/fiverr/gofor.svg)](https://circleci.com/gh/fiverr/gofor)
-[![GitHub issues](https://img.shields.io/github/issues/fiverr/gofor.svg)](https://github.com/fiverr/gofor/issues)
+[![](https://img.shields.io/npm/v/@fiverr/gofor.svg)](https://www.npmjs.com/package/@fiverr/gofor)
+[![](https://img.shields.io/circleci/project/github/fiverr/gofor.svg)](https://circleci.com/gh/fiverr/gofor)
+[![](https://badges.greenkeeper.io/fiverr/gofor.svg)](https://greenkeeper.io/)
 
 gofor is a (Gofor) factory interface for a lean fetch decorator that *deep reverse merges* default options.
 It means the headers you put in for each request will take precedence, but will supplemented with the defaults.
@@ -14,15 +14,23 @@ The index is a factory, returning the wrapped fetch. It is recommended to use th
 `npm i -S @fiverr/gofor`
 
 ## Use
-### Create an instance:
+### Instances are usable straight "out of the box"
+```js
+const {gofor} = require('@fiverr/gofor');
+gofor('/page', {headers: {'X-Custom-Header': 'Custom-Value'}})
+    .then(...)
+    .catch(...);
+```
+
+### Get an instance and configure it:
 ```javascript
-const goforFactory = require('@fiverr/gofor');
+const {gofor} = require('@fiverr/gofor');
 const defaultHeaders = new Headers();
 defaultHeaders.append('X-Requested-With', 'XMLHttpRequest');
 defaultHeaders.append('Content-Type', 'application/json; charset=utf-8');
 defaultHeaders.append('Accept', 'application/json');
 
-const gofor = goforFactory({
+gofor.config({
     credentials: 'same-origin',
     headers: defaultHeaders
 });
@@ -43,7 +51,7 @@ gofor('/page', {
 
 ##### Example
 ```js
-const gofor = goforFactory({
+gofor.config({
     credentials: 'same-origin',
     headers: new Headers({
         'Content-Type': 'application/json; charset=utf-8',
@@ -63,6 +71,14 @@ Final headers will be:
     'X-Custom-Header': 'Custom-Value'
 ```
 
+### Each gofor getter creates a new instance
+```js
+const gofor1 = require('@fiverr/gofor').gofor;
+const gofor2 = require('@fiverr/gofor').gofor;
+
+gofor1 === gofor2 // false
+```
+
 ## Node Runtime
 Gofor is designed for the browser, and depends on the fetch API.
 
@@ -80,8 +96,3 @@ Object.assign(global, {fetch, Headers, Request, Response});
 
 #### `.entries is not a function`
  `Object.entries` is available in node version >= `7.5.0`,
-
-[![Greenkeeper badge](https://badges.greenkeeper.io/fiverr/gofor.svg)](https://greenkeeper.io/)
-[![bitHound Overall Score](https://www.bithound.io/github/fiverr/gofor/badges/score.svg)](https://www.bithound.io/github/fiverr/gofor)
-[![bitHound Dependencies](https://www.bithound.io/github/fiverr/gofor/badges/dependencies.svg)](https://www.bithound.io/github/fiverr/gofor/master/dependencies/npm)
-[![bitHound Dev Dependencies](https://www.bithound.io/github/fiverr/gofor/badges/devDependencies.svg)](https://www.bithound.io/github/fiverr/gofor/master/dependencies/npm)

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,23 @@ const gofor2 = require('@fiverr/gofor').gofor;
 gofor1 === gofor2 // false
 ```
 
+### Gofor Factory: Create an instance using delayed configuration getter
+The function will be called once on first use, and its result will be memoised.
+
+```js
+const goforFactory = require('@fiverr/gofor');
+
+const gofor = goforFactory(() => ({
+    credentials: 'same-origin',
+    headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/json; charset=utf-8',
+        'Accept': 'application/json',
+        'X-Custom-Secret': document.getElementById('secret').value,
+    },
+}));
+```
+
 ## Node Runtime
 Gofor is designed for the browser, and depends on the fetch API.
 

--- a/server/test.js
+++ b/server/test.js
@@ -13,7 +13,7 @@ describe('E2E test', () => {
                 testServer.exec(
                     () => {
                         gofor(`http://localhost:${PORT}`)
-                            .catch(error => {
+                            .catch((error) => {
                                 assert(false, error);
                                 done();
                             });
@@ -31,7 +31,7 @@ describe('E2E test', () => {
                 testServer.exec(
                     () => {
                         gofor(`http://localhost:${PORT}`, {headers: {'X-Custom-Header-A': 'Custom-Value-A'}})
-                            .catch(error => {
+                            .catch((error) => {
                                 assert(false, error);
                                 done();
                             });
@@ -50,8 +50,8 @@ describe('E2E test', () => {
                 testServer.exec(
                     () => {
                         gofor(`http://localhost:${PORT}`, {headers: {'X-Custom-Header-A': 'Custom-Value-A',
-                                'X-Custom-Header': 'Custom-Value-X'}})
-                            .catch(error => {
+                            'X-Custom-Header': 'Custom-Value-X'}})
+                            .catch((error) => {
                                 assert(false, error);
                                 done();
                             });
@@ -77,7 +77,7 @@ describe('E2E test', () => {
                 testServer.exec(
                     () => {
                         gofor(`http://localhost:${PORT}`)
-                            .catch(error => {
+                            .catch((error) => {
                                 assert(false, error);
                                 done();
                             });
@@ -98,7 +98,7 @@ describe('E2E test', () => {
                 testServer.exec(
                     () => {
                         gofor(`http://localhost:${PORT}`, {headers})
-                            .catch(error => {
+                            .catch((error) => {
                                 assert(false, error);
                                 done();
                             });
@@ -123,7 +123,7 @@ describe('E2E test', () => {
                 testServer.exec(
                     () => {
                         gofor(`http://localhost:${PORT}`, {headers: supplied})
-                            .catch(error => {
+                            .catch((error) => {
                                 assert(false, error);
                                 done();
                             });

--- a/test-helpers.js
+++ b/test-helpers.js
@@ -5,5 +5,5 @@ global.Headers = global.fetch.Headers;
 
 // while lib is tested on Node 6.x.x
 if (!Object.values) {
-    Object.values = obj => Object.keys(obj).map(key => obj[key]);
+    Object.values = (obj) => Object.keys(obj).map((key) => obj[key]);
 }

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ const defaults = {
 
 const catcher = (error) => {
     console.warn(`${error.name} (${error.code}): ${error.message}`);
-    return new Promise(res => res());
+    return new Promise((res) => res());
 };
 
 const goforFactory = require('./');

--- a/test.js
+++ b/test.js
@@ -31,3 +31,21 @@ describe('goforFactory', () => {
             });
     });
 });
+
+describe('gofor instance', () => {
+    it('creates new instanced of gofor', () => {
+        const {gofor} = require('.');
+        const gofor2 = require('.').gofor;
+
+        expect(gofor2).to.not.equal(gofor);
+
+        expect(gofor.config()).to.not.have.key('headers');
+
+        gofor.config({
+            headers: {'Content-Type': 'text-plain'}
+        });
+
+        expect(gofor.config()).to.have.key('headers');
+        expect(gofor2.config()).to.not.have.key('headers');
+    });
+});


### PR DESCRIPTION
1st commit is maintenance, please address only the changes in the 2nd commit 2a2031c

Get a gofor instance directly. Gofor instances are now configurable also after creation
```js
const {gofor} = require('@fiverr/gofor');

// Use is straight out of the box
gofor('http://whatthecommit.com/index.txt')
  .then(...)
  .catch(...);

// Configure later
gofor.config({credentials: 'same-origin', headers: {'Content-Type', 'application/json; charset=utf-8'}});

// Use with configuration
gofor('https://www.website.com/data')
    .then(res => res.json())
	.then(data => doSomethig(data))
	.catch(error => { throw(error); });
```

Old API Still supported