### PR TITLE
Add server port

### DIFF
--- a/configuration/test_server.js
+++ b/configuration/test_server.js
@@ -1,0 +1,47 @@
+const http = require('http');
+const noop = () => {}; // eslint-disable-line no-empty-function
+
+/**
+ * TestServer
+ * @private
+ * @param {number} [port]
+ */
+module.exports = class TestServer {
+    constructor(port = 1337) {
+        this.port = port;
+        this.node = null;
+    }
+
+    /**
+     * Executes a test on a server
+     * @param  {Function} premise
+     * @param  {Function} test
+     * no return value
+     */
+    exec(premise = noop, test = noop, done = noop) {
+        this.node && this.node.close();
+
+        this.node = http.createServer((request, response) => {
+            setTimeout(() => {
+                this.node.close();
+                done();
+            }, 300);
+
+            test(request);
+
+            response.writeHead(201, { 'Content-Type': 'text/plain' });
+            response.end('okay');
+        });
+
+        this.node.keepAliveTimeout = 1000;
+        this.node.listen(this.port);
+
+        this.node.on('error', (error) => console.error(error.stack)); // eslint-disable-line no-console
+
+        this.node.on('connection', (socket) => socket.setTimeout(1500));
+
+        premise();
+
+        return this.node;
+    }
+};

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "lint": "eslint src lib",
     "prepublishOnly": "npm t && npm run lint"
   },
+  "dependencies": {
+    "node-fetch": "^2.2.0"
+  },
   "devDependencies": {
     "@fiverr/eslint-config-fiverr": "^1.0.0",
     "chai": "^4.1.2",
     "eslint": "^5.2.0",
     "eslint-plugin-react": "^7.10.0",
-    "mocha": "^5.2.0",
-    "node-fetch": "^2.2.0"
+    "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm t && npm run lint"
   },
   "dependencies": {
-    "node-fetch": "^2.2.0"
+    "node-fetch": "^2.2.1"
   },
   "devDependencies": {
     "@fiverr/eslint-config-fiverr": "^1.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,47 +1,26 @@
-const http = require('http');
-const noop = () => {}; // eslint-disable-line no-empty-function
+/**
+ * @module gofor/node
+ * @since 2.0.0
+ * @requires gofor
+ */
+
+const fetch = require('node-fetch');
+const Gofor = require('../src');
 
 /**
- * TestServer
- * @private
- * @param {number} [port]
+ * @class GoforNode
+ * @classdesc Returns a wrapper with a "fetch" method decorator that *reverse merges* default headers
+ *
+ * @param  {Object|Function} def Either the default headers or a method to be called one time and returns the default headers object
  */
-module.exports = class TestServer {
-    constructor(port = 1337) {
-        this.port = port;
-        this.node = null;
+class GoforNode extends Gofor {
+    get fetcher() {
+        return fetch;
     }
 
-    /**
-     * Executes a test on a server
-     * @param  {Function} premise
-     * @param  {Function} test
-     * no return value
-     */
-    exec(premise = noop, test = noop, done = noop) {
-        this.node && this.node.close();
-
-        this.node = http.createServer((request, response) => {
-            setTimeout(() => {
-                this.node.close();
-                done();
-            }, 300);
-
-            test(request);
-
-            response.writeHead(201, { 'Content-Type': 'text/plain' });
-            response.end('okay');
-        });
-
-        this.node.keepAliveTimeout = 1000;
-        this.node.listen(this.port);
-
-        this.node.on('error', (error) => console.error(error.stack)); // eslint-disable-line no-console
-
-        this.node.on('connection', (socket) => socket.setTimeout(1500));
-
-        premise();
-
-        return this.node;
+    get interfaces() {
+        return fetch;
     }
-};
+}
+
+module.exports = GoforNode;

--- a/server/test.js
+++ b/server/test.js
@@ -1,144 +1,26 @@
-const TestServer = require('./');
-const PORT = 3344;
-const testServer = new TestServer(PORT);
-const Gofor = require('..');
+const fetch = require('node-fetch');
+const GoforNode = require('.');
 
-describe('E2E test', () => {
-    describe('Headers', () => {
-        describe('As object literals', () => {
+describe('Gofor/node', () => {
+    const gofor = new GoforNode();
 
-            it('accepts headers as an object literal (defaults)', (done) => {
-                const gofor = new Gofor({
-                    headers: {'X-Custom-Header': 'Custom-Value'}
-                });
+    it('Implements node-fetch as the fetcher utility', () => {
+        assert.equal(
+            gofor.fetcher,
+            fetch
+        );
+    });
 
-                testServer.exec(
-                    () => {
-                        gofor.fetch(`http://localhost:${PORT}`)
-                            .catch((error) => {
-                                assert(false, error);
-                                done();
-                            });
-                    },
-                    (request) => {
-                        assert.equal(request.headers['x-custom-header'], 'Custom-Value');
-                        done();
-                    }
-                );
-            });
-
-            it('accepts headers as an object literal (supplied)', (done) => {
-                const gofor = new Gofor({
-                    headers: {'X-Custom-Header': 'Custom-Value'}
-                });
-
-                testServer.exec(
-                    () => {
-                        gofor.fetch(`http://localhost:${PORT}`, {headers: {'X-Custom-Header-A': 'Custom-Value-A'}})
-                            .catch((error) => {
-                                assert(false, error);
-                                done();
-                            });
-                    },
-                    (request) => {
-                        assert.equal(request.headers['x-custom-header'], 'Custom-Value');
-                        assert.equal(request.headers['x-custom-header-a'], 'Custom-Value-A');
-                        done();
-                    }
-                );
-            });
-
-            it('supplied headers *RUN OVER* defaults', (done) => {
-                const gofor = new Gofor({
-                    headers: {'X-Custom-Header': 'Custom-Value'}
-                });
-
-                testServer.exec(
-                    () => {
-                        gofor.fetch(`http://localhost:${PORT}`, {headers: {'X-Custom-Header-A': 'Custom-Value-A',
-                            'X-Custom-Header': 'Custom-Value-X'}})
-                            .catch((error) => {
-                                assert(false, error);
-                                done();
-                            });
-                    },
-                    (request) => {
-                        assert.equal(request.headers['x-custom-header'], 'Custom-Value-X');
-                        assert.equal(request.headers['x-custom-header-a'], 'Custom-Value-A');
-                        done();
-                    }
-                );
-            });
-        });
-
-        describe('As a Headers instance', () => {
-            it('accepts headers a Headers instance (defaults)', (done) => {
-                const headers = new Headers();
-                headers.append('X-Custom-Header', 'Custom-Value');
-
-                const gofor = new Gofor({headers});
-
-                testServer.exec(
-                    () => {
-                        gofor.fetch(`http://localhost:${PORT}`)
-                            .catch((error) => {
-                                assert(false, error);
-                                done();
-                            });
-                    },
-                    (request) => {
-                        expect(request.headers['x-custom-header']).to.equal('Custom-Value');
-                    },
-                    done
-                );
-            });
-
-            it('accepts headers a Headers instance (supplied)', (done) => {
-                const gofor = new Gofor();
-
-                const headers = new Headers();
-                headers.append('X-Custom-Header', 'Custom-Value');
-
-                testServer.exec(
-                    () => {
-                        gofor.fetch(`http://localhost:${PORT}`, {headers})
-                            .catch((error) => {
-                                assert(false, error);
-                                done();
-                            });
-                    },
-                    (request) => {
-                        expect(request.headers['x-custom-header']).to.equal('Custom-Value');
-                    },
-                    done
-                );
-            });
-
-            it('supplied headers *RUN OVER* defaults', (done) => {
-                const headers = new Headers();
-                headers.append('X-Custom-Header', 'Custom-Value');
-
-                const supplied = new Headers();
-                supplied.append('X-Custom-Header', 'Custom-Value-X');
-                supplied.append('X-Custom-Header-A', 'Custom-Value-A');
-
-                const gofor = new Gofor({headers});
-
-                testServer.exec(
-                    () => {
-                        gofor.fetch(`http://localhost:${PORT}`, {headers: supplied})
-                            .catch((error) => {
-                                assert(false, error);
-                                done();
-                            });
-                    },
-                    (request) => {
-                        expect(request.headers['x-custom-header']).to.equal('Custom-Value-X');
-                        expect(request.headers['x-custom-header-a']).to.equal('Custom-Value-A');
-                    },
-                    done
-                );
-            });
+    it('Implements node-fetch interface constructors', () => {
+        [
+            'Headers',
+            'Request',
+            'Response'
+        ].forEach((constructor) => {
+            assert.equal(
+                gofor.interfaces[constructor],
+                fetch[constructor]
+            );
         });
     });
 });

--- a/src/tests/e2e.test.js
+++ b/src/tests/e2e.test.js
@@ -1,0 +1,144 @@
+const TestServer = require('../../configuration/test_server');
+const PORT = 3344;
+const testServer = new TestServer(PORT);
+const Gofor = require('..');
+
+describe('E2E test', () => {
+    describe('Headers', () => {
+        describe('As object literals', () => {
+
+            it('accepts headers as an object literal (defaults)', (done) => {
+                const gofor = new Gofor({
+                    headers: {'X-Custom-Header': 'Custom-Value'}
+                });
+
+                testServer.exec(
+                    () => {
+                        gofor.fetch(`http://localhost:${PORT}`)
+                            .catch((error) => {
+                                assert(false, error);
+                                done();
+                            });
+                    },
+                    (request) => {
+                        assert.equal(request.headers['x-custom-header'], 'Custom-Value');
+                        done();
+                    }
+                );
+            });
+
+            it('accepts headers as an object literal (supplied)', (done) => {
+                const gofor = new Gofor({
+                    headers: {'X-Custom-Header': 'Custom-Value'}
+                });
+
+                testServer.exec(
+                    () => {
+                        gofor.fetch(`http://localhost:${PORT}`, {headers: {'X-Custom-Header-A': 'Custom-Value-A'}})
+                            .catch((error) => {
+                                assert(false, error);
+                                done();
+                            });
+                    },
+                    (request) => {
+                        assert.equal(request.headers['x-custom-header'], 'Custom-Value');
+                        assert.equal(request.headers['x-custom-header-a'], 'Custom-Value-A');
+                        done();
+                    }
+                );
+            });
+
+            it('supplied headers *RUN OVER* defaults', (done) => {
+                const gofor = new Gofor({
+                    headers: {'X-Custom-Header': 'Custom-Value'}
+                });
+
+                testServer.exec(
+                    () => {
+                        gofor.fetch(`http://localhost:${PORT}`, {headers: {'X-Custom-Header-A': 'Custom-Value-A',
+                            'X-Custom-Header': 'Custom-Value-X'}})
+                            .catch((error) => {
+                                assert(false, error);
+                                done();
+                            });
+                    },
+                    (request) => {
+                        assert.equal(request.headers['x-custom-header'], 'Custom-Value-X');
+                        assert.equal(request.headers['x-custom-header-a'], 'Custom-Value-A');
+                        done();
+                    }
+                );
+            });
+        });
+
+        describe('As a Headers instance', () => {
+            it('accepts headers a Headers instance (defaults)', (done) => {
+                const headers = new Headers();
+                headers.append('X-Custom-Header', 'Custom-Value');
+
+                const gofor = new Gofor({headers});
+
+                testServer.exec(
+                    () => {
+                        gofor.fetch(`http://localhost:${PORT}`)
+                            .catch((error) => {
+                                assert(false, error);
+                                done();
+                            });
+                    },
+                    (request) => {
+                        expect(request.headers['x-custom-header']).to.equal('Custom-Value');
+                    },
+                    done
+                );
+            });
+
+            it('accepts headers a Headers instance (supplied)', (done) => {
+                const gofor = new Gofor();
+
+                const headers = new Headers();
+                headers.append('X-Custom-Header', 'Custom-Value');
+
+                testServer.exec(
+                    () => {
+                        gofor.fetch(`http://localhost:${PORT}`, {headers})
+                            .catch((error) => {
+                                assert(false, error);
+                                done();
+                            });
+                    },
+                    (request) => {
+                        expect(request.headers['x-custom-header']).to.equal('Custom-Value');
+                    },
+                    done
+                );
+            });
+
+            it('supplied headers *RUN OVER* defaults', (done) => {
+                const headers = new Headers();
+                headers.append('X-Custom-Header', 'Custom-Value');
+
+                const supplied = new Headers();
+                supplied.append('X-Custom-Header', 'Custom-Value-X');
+                supplied.append('X-Custom-Header-A', 'Custom-Value-A');
+
+                const gofor = new Gofor({headers});
+
+                testServer.exec(
+                    () => {
+                        gofor.fetch(`http://localhost:${PORT}`, {headers: supplied})
+                            .catch((error) => {
+                                assert(false, error);
+                                done();
+                            });
+                    },
+                    (request) => {
+                        expect(request.headers['x-custom-header']).to.equal('Custom-Value-X');
+                        expect(request.headers['x-custom-header-a']).to.equal('Custom-Value-A');
+                    },
+                    done
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Main Change

Add a `gofor` port for servers, under the `server` directory.
The module uses `node-fetch` both for the fetcher function, and for the interface constructors (`Headers`, `Request`, etc.).

### Additional Changes

- Move the test server module to `configuration`.
- Move the E2E test to `gofor/tests`.
- Upgrade `node-fetch`.