### PR TITLE
Readability - how it's different that headers *run over* defaults

### DIFF
--- a/src/tests/e2e.test.js
+++ b/src/tests/e2e.test.js
@@ -120,6 +120,7 @@ describe('E2E test', () => {
 
                 const supplied = new Headers();
                 supplied.append('X-Custom-Header', 'Custom-Value-X');
+                supplied.append('X-Custom-Header', 'Custom-Value-Y');
                 supplied.append('X-Custom-Header-A', 'Custom-Value-A');
 
                 const gofor = new Gofor({headers});
@@ -133,7 +134,7 @@ describe('E2E test', () => {
                             });
                     },
                     (request) => {
-                        expect(request.headers['x-custom-header']).to.equal('Custom-Value-X');
+                        expect(request.headers['x-custom-header']).to.equal('Custom-Value-X, Custom-Value-Y');
                         expect(request.headers['x-custom-header-a']).to.equal('Custom-Value-A');
                     },
                     done


### PR DESCRIPTION
Show the default behaviour in the spec