### PR TITLE
Get ready to ship

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fiverr/gofor",
+  "name": "gofor",
   "version": "2.0.0",
   "description": "lean fetch decorator that reverse merges default options",
   "author": "Fiverr",
@@ -29,9 +29,9 @@
     "@babel/preset-env": "^7.1.5",
     "@fiverr/eslint-config-fiverr": "^1.0.0",
     "babel-loader": "^8.0.4",
-    "chai": "^4.1.2",
-    "eslint": "^5.2.0",
-    "eslint-plugin-react": "^7.10.0",
+    "chai": "^4.2.0",
+    "eslint": "^5.8.0",
+    "eslint-plugin-react": "^7.11.1",
     "mocha": "^5.2.0",
     "webpack": "^4.25.1",
     "webpack-cli": "^3.1.2"

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# gofor [![](https://img.shields.io/npm/v/@fiverr/gofor.svg)](https://www.npmjs.com/package/@fiverr/gofor) [![](https://img.shields.io/circleci/project/github/fiverr/gofor.svg)](https://circleci.com/gh/fiverr/gofor)
+# gofor [![](https://img.shields.io/npm/v/gofor.svg)](https://www.npmjs.com/package/gofor) [![](https://img.shields.io/circleci/project/github/fiverr/gofor.svg)](https://circleci.com/gh/fiverr/gofor)
 
 Each Gofor instance exposes a fetch method: a lean [fetch decorator](https://developer.mozilla.org/en/docs/Web/API/Fetch_API) that *deep reverse merges* default options.
 
@@ -6,12 +6,12 @@ Options you pass through in for each request will take precedence, but will supp
 
 ## Install
 ```
-npm i -S @fiverr/gofor
+npm i gofor
 ```
 
 ## Using the constructor
 ```js
-const Gofor = require('@fiverr/gofor');
+const Gofor = require('gofor');
 const myGofor = new Gofor({headers: {'X-Custom-Header': 'Custom-Value'}});
 myGofor.fetch('/page')
     .then(...)
@@ -20,7 +20,7 @@ myGofor.fetch('/page')
 
 ### "out of the box" usability with instances
 ```js
-const {gofor} = require('@fiverr/gofor');
+const {gofor} = require('gofor');
 gofor('/page').then(...); // This is the fetch
 gofor.config({headers: {'X-Custom-Header': 'Custom-Value'}});
 gofor('/page').then(...); // Now includes default settings
@@ -28,7 +28,7 @@ gofor('/page').then(...); // Now includes default settings
 
 ### Configuring an instance
 ```javascript
-const {gofor} = require('@fiverr/gofor');
+const {gofor} = require('gofor');
 const defaultHeaders = new Headers();
 defaultHeaders.append('X-Requested-With', 'XMLHttpRequest');
 defaultHeaders.append('Content-Type', 'application/json; charset=utf-8');
@@ -77,8 +77,8 @@ Final headers will be:
 
 ### Each gofor getter creates a new instance
 ```js
-const gofor1 = require('@fiverr/gofor').gofor;
-const gofor2 = require('@fiverr/gofor').gofor;
+const gofor1 = require('gofor').gofor;
+const gofor2 = require('gofor').gofor;
 
 gofor1 === gofor2 // false
 ```
@@ -87,7 +87,7 @@ gofor1 === gofor2 // false
 The function will be called once on first use, and its result will be memoised. useful for cases where you need to pull information from the document and don't want to create a race condition.
 
 ```js
-const {gofor} = require('@fiverr/gofor');
+const {gofor} = require('gofor');
 
 gofor.config(() => ({
     credentials: 'same-origin',
@@ -103,5 +103,5 @@ gofor.config(() => ({
 ## Node Runtime
 Gofor brings a pre baked node compatible flavour using [node-fetch](https://www.npmjs.com/package/node-fetch).
 ```js
-const {gofor} = require('@fiverr/gofor/node');
+const {gofor} = require('gofor/node');
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -7,21 +7,16 @@
 const iterate = require('../lib/iterate');
 
 /**
- * A Symbol-like primitive.
- * @typedef {(Symbol|String)} SymbolLike
- */
-
-/**
  * Defaults private key.
- * @type {SymbolLike}
+ * @type {Symbol}
  */
-const defaultsKey = typeof Symbol === 'function' ? Symbol() : '_defaults';
+const defaultsKey = Symbol();
 
 /**
  * Get defaults method private key.
- * @type {SymbolLike}
+ * @type {Symbol}
  */
-const getDefaults = typeof Symbol === 'function' ? Symbol() : '_getDefaults';
+const getDefaults = Symbol();
 
 /**
  * Defines the defaults' initial values, and the instance's getDefaults method.
@@ -55,6 +50,7 @@ function defineDefaults(defaults) {
  * @classdesc Returns a wrapper with a "fetch" method decorator that *reverse merges* default headers
  *
  * @param    {Object|Function} defaults Default options to be used for each request.
+ * @classProperty {Function}   gofor a fresh fetcher instance
  * @property {Function}        fetcher The function used to perform requests.
  * @property {Object}          interfaces The request interface constructors.
  * @property {Boolean}         supportsHeaders Whether the Headers constructor is available or not.
@@ -135,11 +131,10 @@ class Gofor {
     /**
      * Modify the default options
      * @param {Object} opts The new options to set.
+     * no return value
      */
     config(opts = null) {
-        this[defaultsKey] = this.mergeOptions(opts);
-
-        return this[defaultsKey];
+        defineDefaults.call(this, opts);
     }
 
     /**

--- a/src/tests/config.test.js
+++ b/src/tests/config.test.js
@@ -7,16 +7,20 @@ describe('Gofor', () => {
         const gofor = new Gofor(() => defaults());
         const {fetch} = gofor;
 
-        it('Should modify the defaults', () => {
+        it('Should run over the defaults', () => {
             const headers = new Headers();
             headers.append('Content-Type', 'text-plain');
 
+            assert.equal(gofor.defaults.headers['X-Custom-Authentication'], defaults().headers['X-Custom-Authentication']);
+            assert.equal(gofor.defaults.headers['X-Requested-With'], 'XMLHttpRequest');
+
             fetch.config({headers});
 
-            const options = gofor.defaults;
-            assert.equal(options.headers.get('Content-Type'), 'text-plain');
-            assert.equal(options.headers.get('X-Custom-Authentication'), defaults().headers['X-Custom-Authentication']);
-            assert.equal(options.headers.get('X-Requested-With'), 'XMLHttpRequest');
+            assert.equal(gofor.defaults.headers.get('Content-Type'), 'text-plain');
+            assert.equal(gofor.defaults.headers['X-Custom-Authentication'], null);
+            assert.equal(gofor.defaults.headers['X-Requested-With'], null);
+            assert.equal(gofor.defaults.headers.get('X-Custom-Authentication'), null);
+            assert.equal(gofor.defaults.headers.get('X-Requested-With'), null);
         });
     });
 });


### PR DESCRIPTION
Migration from 1.X to 2 (also from `@fiverr/gofor` to plain `gofor`)

"Out of the box" Instance remains the same

Before
```js
const {gofor} = require('@fiverr/gofor');
```

After
```js
const {gofor} = require('gofor');
```

replace use of goforFactory (deprecated); two options are available

Before
```js
const goforFactory = require('@fiverr/gofor');

const gofor = goforFactory(() => ({...}));
```

After
```js
const Gofor = require('gofor');

const gofor = new Gofor(() => ({...})).fetch;
```

Or
```js
const {gofor} = require('gofor');

gofor.config(() => ({...}))
```