### PR TITLE
🐛Gofor node: gofor getter and Headers interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofor",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "lean fetch decorator that reverse merges default options",
   "keywords": [
     "fetch",

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,10 @@ const Gofor = require('../src');
  * @param  {Object|Function} def Either the default headers or a method to be called one time and returns the default headers object
  */
 class GoforNode extends Gofor {
+    static get gofor() {
+        return new GoforNode().fetch;
+    }
+
     get fetcher() {
         return fetch;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -155,8 +155,8 @@ class Gofor {
      * @return {Headers}
      */
     toHeaders(headers) {
-        if (headers && typeof headers === 'object' && this.supportsHeaders && !(headers instanceof Headers)) {
-            const { Headers } = this.interfaces;
+        const { Headers } = this.interfaces;
+        if (headers && typeof headers === 'object' && this.supportsHeaders && Headers && !(headers instanceof Headers)) {
             const result = new Headers();
 
             Object.keys(headers).forEach(

--- a/src/tests/headers.test.js
+++ b/src/tests/headers.test.js
@@ -12,9 +12,10 @@ describe('Gofor', () => {
 
         it('When Headers is not available, new values override defaults', () => {
             delete require.cache[require.resolve('..')];
-            delete global.Headers;
+            global.Headers = null;
 
             const Gofor = require('..');
+
             let called = false;
 
             global.fetch = (url, {headers}) => {

--- a/src/tests/supports_headers.test.js
+++ b/src/tests/supports_headers.test.js
@@ -8,7 +8,7 @@ describe('Gofor', () => {
 
         it('Does not convert headers when Headers is unavailable', () => {
             delete require.cache[require.resolve('..')];
-            delete global.Headers;
+            global.Headers = null;
             const Gofor = require('..');
             const gofor = new Gofor();
 

--- a/src/tests/to_headers.test.js
+++ b/src/tests/to_headers.test.js
@@ -19,7 +19,7 @@ describe('Gofor', () => {
 
         it('Does not convert headers when Headers is unavailable', () => {
             delete require.cache[require.resolve('..')];
-            delete global.Headers;
+            global.Headers = null;
             const Gofor = require('..');
             const gofor = new Gofor;
 


### PR DESCRIPTION
- static gofor getter - retirn node version instead of browser version
- use Headers from interfaces