### PR TITLE
[FIX] Gofor server lib require

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofor",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "lean fetch decorator that reverse merges default options",
   "keywords": [
     "fetch",

--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,7 @@
  * @requires gofor
  */
 
-const fetch = require('node-fetch');
+const fetch = require('node-fetch/lib');
 const Gofor = require('../src');
 
 /**


### PR DESCRIPTION
Content: 
- Migrate node-fetch require to work explicit for lib

Why: 
 - Currently, when npm package uses webpack browser entry config and trying to require node-fetch, it will arrive as **Module**, There for there is a need to require it explicit from the lib to ensure a consistent behaviour. 