### PR TITLE
Add error message for deprecated require path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofor",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Lean, isomorphic fetch decorator that reverse merges default options",
   "keywords": [
     "fetch",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,1 @@
+throw new Error("Gofor is now meant to be isomorphic and 'gofor/server' module has been discontinued.\nPlease consume gofor directly:\nconst Gofor = require('gofor');");


### PR DESCRIPTION
Replace this
![](https://user-images.githubusercontent.com/516342/55286943-26624c00-53ab-11e9-8c27-c16ae240d554.png)

With a more helpful error message
```
Error: Gofor is now meant to be isomorphic and 'gofor/server' module has been discontinued.
Please consume gofor directly:
const Gofor = require('gofor');
```