### PR TITLE
Reinstate browser entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "engines": {
     "node": ">=8.9.0"
   },
-  "main": "./src/index.js",
+  "main": "./src/server.js",
+  "browser": "./src/browser.js",
   "scripts": {
     "test": "mocha --opts configuration/mocha.opts './{,!(node_modules)/**}/test.js' './{,!(node_modules)/**}/*.test.js'",
     "test:single": "mocha --opts configuration/mocha.opts ",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofor",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Lean, isomorphic fetch decorator that reverse merges default options",
   "keywords": [
     "fetch",

--- a/src/browser.js
+++ b/src/browser.js
@@ -4,7 +4,6 @@
  * @requires iterate
  */
 
-const fetch = require('node-fetch');
 const iterate = require('../lib/iterate');
 
 /**
@@ -53,6 +52,8 @@ function defineDefaults(defaults) {
  * @param    {Object|Function} defaults Default options to be used for each request.
  * @classProperty {Function}   gofor a fresh fetcher instance
  * @property {Object}          defaults The default options.
+ * @property {Function}        fetcher The function used to perform requests.
+ * @property {Object}          interfaces The request interface constructors.
  */
 class Gofor {
     constructor(defaults = {}) {
@@ -67,7 +68,7 @@ class Gofor {
         this.fetch = (...args) => {
             args[1] = this.mergeOptions(args[1]);
 
-            return fetch(...args);
+            return this.fetcher(...args);
         };
 
         this.fetch.config = this.config.bind(this);
@@ -83,6 +84,20 @@ class Gofor {
 
     set defaults(obj) {
         throw new RangeError('Gofor Error: Modifying a Gofor instance defaults is not allowed');
+    }
+
+    get fetcher() {
+        return function(...args) {
+            return fetch(...args);
+        };
+    }
+
+    get interfaces() {
+        return {
+            Headers,
+            Request,
+            Response
+        };
     }
 
     /**
@@ -131,7 +146,7 @@ class Gofor {
      * @return {Headers}
      */
     toHeaders(headers) {
-        const { Headers } = fetch;
+        const { Headers } = this.interfaces;
         if (headers && typeof headers === 'object' && Headers && !(headers instanceof Headers)) {
             const result = new Headers();
 
@@ -152,7 +167,7 @@ class Gofor {
      */
     mergeHeaders(submitted) {
         const defaults = this.defaults.headers;
-        const { Headers } = fetch;
+        const { Headers } = this.interfaces;
         const headers = new Headers();
         const keys = [];
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
 /**
  * @module gofor/node
- * @since 2.0.0
+ * @since 3.0.2
  * @requires gofor
  */
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,30 @@
+/**
+ * @module gofor/node
+ * @since 2.0.0
+ * @requires gofor
+ */
+
+const fetch = require('node-fetch');
+const Gofor = require('./browser');
+
+/**
+ * @class GoforNode
+ * @classdesc Returns a wrapper with a "fetch" method decorator that *reverse merges* default headers
+ *
+ * @param  {Object|Function} def Either the default headers or a method to be called one time and returns the default headers object
+ */
+class GoforNode extends Gofor {
+    static get gofor() {
+        return new GoforNode().fetch;
+    }
+
+    get fetcher() {
+        return fetch;
+    }
+
+    get interfaces() {
+        return fetch;
+    }
+}
+
+module.exports = GoforNode;

--- a/src/tests/config.test.js
+++ b/src/tests/config.test.js
@@ -1,4 +1,4 @@
-const Gofor = require('..');
+const Gofor = require('../browser');
 
 const { defaults } = require('./helpers');
 

--- a/src/tests/defaults.test.js
+++ b/src/tests/defaults.test.js
@@ -1,4 +1,4 @@
-const Gofor = require('..');
+const Gofor = require('../browser');
 
 const { defaults } = require('./helpers');
 

--- a/src/tests/e2e.test.js
+++ b/src/tests/e2e.test.js
@@ -1,7 +1,7 @@
 const TestServer = require('../../configuration/test_server');
 const PORT = 3344;
 const testServer = new TestServer(PORT);
-const Gofor = require('..');
+const Gofor = require('../browser');
 
 describe('E2E test', () => {
     describe('Headers', () => {

--- a/src/tests/fetch.test.js
+++ b/src/tests/fetch.test.js
@@ -1,4 +1,4 @@
-const Gofor = require('..');
+const Gofor = require('../browser');
 
 const { defaults } = require('./helpers');
 

--- a/src/tests/instance.test.js
+++ b/src/tests/instance.test.js
@@ -1,4 +1,4 @@
-const Gofor = require('..');
+const Gofor = require('../browser');
 const {gofor} = Gofor;
 
 describe('gofor', () => {

--- a/src/tests/merge_headers.test.js
+++ b/src/tests/merge_headers.test.js
@@ -1,4 +1,4 @@
-const Gofor = require('..');
+const Gofor = require('../browser');
 
 const { parseHeaders } = require('./helpers');
 

--- a/src/tests/merge_options.test.js
+++ b/src/tests/merge_options.test.js
@@ -1,4 +1,4 @@
-const Gofor = require('..');
+const Gofor = require('../browser');
 
 const { defaults } = require('./helpers');
 

--- a/src/tests/server.test.js
+++ b/src/tests/server.test.js
@@ -1,0 +1,26 @@
+const fetch = require('node-fetch');
+const GoforNode = require('../server');
+
+describe('Gofor/node', () => {
+    const gofor = new GoforNode();
+
+    it('Implements node-fetch as the fetcher utility', () => {
+        assert.equal(
+            gofor.fetcher,
+            fetch
+        );
+    });
+
+    it('Implements node-fetch interface constructors', () => {
+        [
+            'Headers',
+            'Request',
+            'Response'
+        ].forEach((constructor) => {
+            assert.equal(
+                gofor.interfaces[constructor],
+                fetch[constructor]
+            );
+        });
+    });
+});

--- a/src/tests/to_headers.test.js
+++ b/src/tests/to_headers.test.js
@@ -1,4 +1,4 @@
-const Gofor = require('..');
+const Gofor = require('../browser');
 
 describe('Gofor', () => {
     describe('toHeaders', () => {


### PR DESCRIPTION
Add an explicit `browser` entry to `package.json` instead of relying on `node-fetch` resolving the environment itself.