### PR TITLE
ci: add PR Monday Notifier workflow

### DIFF
--- a/.github/workflows/pr-monday-notifier.yml
+++ b/.github/workflows/pr-monday-notifier.yml
@@ -1,0 +1,17 @@
+---
+name: PR Monday Notifier
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, edited, closed]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify-monday:
+    uses: fiverr/github_workflows/.github/workflows/pr-monday-notifier.yml@master
+    secrets:
+      MONDAY_API_TOKEN: ${{ secrets.MONDAY_API_TOKEN }}
+      GITHUBOT_TOKEN: ${{ secrets.GITHUBOT_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
## PR Monday Notifier

Adds automated PR to Monday.com tracking to this repo.

**What happens automatically:**
- PR opened - item created in your team's Monday Incoming board (Pending)
- PR reviewed - item moves to In Review, reviewer added to Owner
- PR approved - item moves to Approved
- PR merged/closed - item moves to Merged/Closed

Team routing is based on your repo's CODEOWNERS file.

> No action needed - just merge this PR.

[_Created by Sourcegraph batch change `inbar-havdala/add-pr-monday-notifier`._](https://fiverr.sourcegraph.com/users/inbar-havdala/batch-changes/add-pr-monday-notifier)